### PR TITLE
Add archcontroller level blacklist address set

### DIFF
--- a/src/WildcatMarketController.sol
+++ b/src/WildcatMarketController.sol
@@ -330,6 +330,8 @@ contract WildcatMarketController is IWildcatMarketController , SphereXProtected 
       }
     } else if (msg.sender != address(controllerFactory)) {
       revert CallerNotBorrowerOrControllerFactory();
+    } else if (IWildcatArchController(archController).isBlacklistedAsset(asset)) {
+      revert UnderlyingNotPermitted();
     }
 
     DeployMarketLocals memory locals;

--- a/src/interfaces/IWildcatArchController.sol
+++ b/src/interfaces/IWildcatArchController.sol
@@ -78,6 +78,29 @@ interface IWildcatArchController {
   function removeBorrower(address borrower) external;
 
   /* -------------------------------------------------------------------------- */
+  /*                           Asset Blacklist Registry                         */
+  /* -------------------------------------------------------------------------- */
+  
+  event AssetPermitted();
+
+  event AssetBlacklisted();
+
+  function addBlacklist(address asset) external;
+
+  function removeBlacklist(address asset) external;
+
+  function isBlacklistedAsset(address asset) external view returns (bool);
+
+  function getBlacklistedAssets() external view returns (address[] memory);
+
+  function getBlacklistedAssets(
+    uint256 start,
+    uint256 end
+  ) external view returns (address[] memory);
+
+  function getBlacklistedAssetsCount() external view returns (uint256);
+
+  /* -------------------------------------------------------------------------- */
   /*                               Markets Registry                              */
   /* -------------------------------------------------------------------------- */
 

--- a/src/interfaces/IWildcatMarketControllerEventsAndErrors.sol
+++ b/src/interfaces/IWildcatMarketControllerEventsAndErrors.sol
@@ -19,6 +19,10 @@ interface IWildcatMarketControllerEventsAndErrors {
   // `controllerFactory`.
   error CallerNotBorrowerOrControllerFactory();
 
+  // Error thrown when `deployMarket` is called for an underlying asset which has
+  // been blacklisted by the arch-controller owner.
+  error UnderlyingNotPermitted();
+
   // Error thrown if borrower calls `deployMarket` and is no longer
   // registered with the arch-controller.
   error NotRegisteredBorrower();


### PR DESCRIPTION
Following some preliminary legal advice from finreg lawyers, we're going to want this in place.

It'd make sense to fill this out with rebasing tokens [so that people don't accidentally shoot themselves in the foot], but as the UK decides what qualifies as a security token (a category that is MUCH narrower there than in America) in the future, we're going to want an easy way to gate the ability to create further markets in tokens from the point that they're declared as such.

