### PR TITLE
Broken link replacemen

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -18,7 +18,7 @@ remappings = [
 
 evm_version = 'shanghai'
 
-# See more config options https://github.com/foundry-rs/foundry/tree/master/config
+# See more config options https://github.com/foundry-rs/foundry/tree/master/crates/config
 
 [profile.default.fuzz]
 runs = 1000


### PR DESCRIPTION
It was redirecting to a page with a non-existent link. I've fixed it. Hope it helps. Good luck with your work!